### PR TITLE
マルチステージビルド、DL3045対応

### DIFF
--- a/03/Dockerfile
+++ b/03/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:1.24-alpine3.22 AS builder
+
+WORKDIR /
+COPY main.go .
+RUN go build main.go
+
+FROM alpine:3.22
+
+COPY --from=builder /main /
+
+CMD [ "/main" ]

--- a/03/go.mod
+++ b/03/go.mod
@@ -1,0 +1,3 @@
+module my-go-app
+
+go 1.24.3

--- a/03/main.go
+++ b/03/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+		fmt.Println("Hello, world")
+}


### PR DESCRIPTION
## なぜやるか
マルチステージをすることによって不要なファイルや、依存関係を含まない最小の実行イメージを作ることができ軽い状態で使うことができる

## なにをやったのか
重たいビルド作業を / でやって、軽い実行専用のファイルは/mainに作って、/mainだけを使ってアプリを動かす

## 動作確認の手順
docker build -t 03 .でビルドした後にdocker run --rm 03で走らせて確認

```
docker build -t 03 .
docker run --rm 03
```